### PR TITLE
Fix rubinius name issue with RVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: ruby
 rvm:
   - 2.5
   - 2.4
-  - rubinius-3
+  - rbx
 matrix:
   include:
     - rvm: 2.5.1
@@ -14,7 +14,7 @@ matrix:
       os: osx
       osx_image: xcode9.2
   allow_failures:
-    - rvm: rubinius-3
+    - rvm: rbx
   fast_finish: true
 addons:
   apt:


### PR DESCRIPTION
Fixes:

```
$ rvm use rubinius-3 --install --binary --fuzzy
curl: (22) The requested URL returned error: 404 Not Found
```