### PR TITLE
Remove deprecated rubyforge_project call

### DIFF
--- a/libv8.gemspec
+++ b/libv8.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = %q{Distributes the V8 JavaScript engine in binary and source forms in order to support fast builds of The Ruby Racer}
   s.license     = "MIT"
 
-  s.rubyforge_project = "libv8"
-
   s.files  = `git ls-files`.split("\n").reject {|f| f =~ /^release\//}
 
   submodules = `git submodule --quiet foreach 'echo $path'`.split("\n").map(&:chomp)


### PR DESCRIPTION
This call produces noisy deprecation warnings for rubygems >= 3.1

https://github.com/rubygems/rubygems/blob/dbc9c83b76f3495272a43de4316341cc77cf66c0/History.txt#L255