### PR TITLE
Bump libv8 to 7.3.495

### DIFF
--- a/lib/libv8/version.rb
+++ b/lib/libv8/version.rb
@@ -1,3 +1,3 @@
 module Libv8
-  VERSION = "7.3.492.27.3beta1"
+  VERSION = "7.3.495.0"
 end


### PR DESCRIPTION
## Changes

Bump to the last minor version of 7.3.

## Consideration

Why don't we bump to the last 8.x? We should, however I could confirm rubyjs/mini_racer 0.2.9 gem does not support libv8 8.x yet. So for the time-being, let's settle on the more up-to-date minor version of 7.3.