### PR TITLE
Test against Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 compiler: clang
 language: ruby
 rvm:
+  - 2.6
   - 2.5
   - 2.4
   - rubinius-3


### PR DESCRIPTION
This PR updates the travis config to include Ruby 2.6 in the CI.