### PR TITLE
Bump to 7.3.495.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ dist: xenial
 compiler: clang
 language: ruby
 rvm:
+  - 2.6
   - 2.5
-  - 2.4
   - rubinius-3
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - rbx
 matrix:
   include:
-    - rvm: 2.5.1
+    - rvm: 2.5
       os: osx
       osx_image: xcode9.4.1
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,11 @@ rvm:
   - 2.7
   - 2.6
   - 2.5
-  - rbx
 matrix:
   include:
     - rvm: 2.6
       os: osx
       osx_image: xcode9.4.1
-  allow_failures:
-    - rvm: rbx
   fast_finish: true
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ bundler_args: --jobs=4 --retry=3
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then gem update bundler; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then gem update --system; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx"]; then xcode-select --install; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" -a "$TRAVIS_RUBY_VERSION" == "system" ]; then sudo gem install bundler; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" -a "$TRAVIS_RUBY_VERSION" != "system" ]; then gem update --system; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" -a "$TRAVIS_RUBY_VERSION" != "system" ]; then gem update bundler; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - rbx
 matrix:
   include:
-    - rvm: 2.5
+    - rvm: 2.6
       os: osx
       osx_image: xcode9.4.1
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ language: ruby
 rvm:
   - 2.6
   - 2.5
-  - rubinius-3
+  - rbx
 matrix:
   include:
     - rvm: 2.5.1
       os: osx
       osx_image: xcode9.4.1
   allow_failures:
-    - rvm: rubinius-3
+    - rvm: rbx
   fast_finish: true
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
     - rvm: 2.5.1
       os: osx
       osx_image: xcode9.4.1
-    - rvm: 2.5.1
-      os: osx
-      osx_image: xcode9.2
   allow_failures:
     - rvm: rubinius-3
   fast_finish: true
@@ -25,7 +22,6 @@ bundler_args: --jobs=4 --retry=3
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then gem update bundler; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then gem update --system; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx"]; then xcode-select --install; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" -a "$TRAVIS_RUBY_VERSION" == "system" ]; then sudo gem install bundler; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" -a "$TRAVIS_RUBY_VERSION" != "system" ]; then gem update --system; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" -a "$TRAVIS_RUBY_VERSION" != "system" ]; then gem update bundler; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 compiler: clang
 language: ruby
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - rbx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update upstream v8 version to 7.3.495.0
 * Enable I18n support in V8
+* Drop support for Ruby 2.4 (EOL)
 
 ### v7.3.492.27.0, v7.3.492.27.1 - 2019-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### Unreleased
+### v7.3.495.0 - 2020-04-14
 
+* Update upstream v8 version to 7.3.495.0
 * Enable I18n support in V8
 
 ### v7.3.492.27.0, v7.3.492.27.1 - 2019-04-24

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # libv8
 [![Gem Version](https://badge.fury.io/rb/libv8.svg)](https://badge.fury.io/rb/libv8)
 [![Number of downloads](https://ruby-gem-downloads-badge.herokuapp.com/libv8?type=total)](https://rubygems.org/gems/libv8)
-[![Build Status](https://travis-ci.org/cowboyd/libv8.svg?branch=master)](https://travis-ci.org/cowboyd/libv8)
+[![Build Status](https://travis-ci.org/rubyjs/libv8.svg?branch=master)](https://travis-ci.org/rubyjs/libv8)
 [![Join the chat at https://gitter.im/cowboyd/therubyracer](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cowboyd/therubyracer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Code Triagers Badge](https://www.codetriage.com/cowboyd/libv8/badges/users.svg)](https://www.codetriage.com/cowboyd/libv8)
 
@@ -79,11 +79,11 @@ source-based distribution
 
 Building the V8 library from source imposes the following requirements:
 
-* An x86/x86_64 CPU. See [#261](https://github.com/cowboyd/libv8/issues/261) for ARM state.
+* An x86/x86_64 CPU. See [#261](https://github.com/rubyjs/libv8/issues/261) for ARM state.
 * Linux with glibc or macOS. See
-  [#259](https://github.com/cowboyd/libv8/issues/259),
-  [#253](https://github.com/cowboyd/libv8/issues/253) and
-  [#217](https://github.com/cowboyd/libv8/issues/217) for state of other
+  [#259](https://github.com/rubyjs/libv8/issues/259),
+  [#253](https://github.com/rubyjs/libv8/issues/253) and
+  [#217](https://github.com/rubyjs/libv8/issues/217) for state of other
   platforms.
 * Python 2
 * pkg-config
@@ -96,7 +96,7 @@ so by specifying the git repo as a gem source. Just make sure you add
 the following to your `Gemfile`:
 
 ```Ruby
-gem "libv8", github: "cowboyd/libv8", submodules: true
+gem "libv8", github: "rubyjs/libv8", submodules: true
 ```
 
 You can find more info on using a git repo as a gem source in
@@ -109,7 +109,7 @@ platform, we'll pull it right in!
 
 To get the source, these commands will get you started:
 
-    git clone --recursive git://github.com/cowboyd/libv8.git
+    git clone --recursive git://github.com/rubyjs/libv8.git
     cd libv8
     bundle install
     bundle exec rake compile
@@ -117,7 +117,7 @@ To get the source, these commands will get you started:
 ### About
 
 This project spun off of
-[therubyracer](http://github.com/cowboyd/therubyracer) which depends
+[therubyracer](http://github.com/rubyjs/therubyracer) which depends
 on having a specific version of V8 to compile and run against.
 However, actually delivering that version reliably to all the
 different platforms proved to be a challenge to say the least.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ opens the door for supporting Windows.
 That depends on your platform. Right now, we support the following
 platforms.
 
+* x86_64-darwin-19
+* x86_64-darwin-18
 * x86_64-darwin-17
 * x86_64-darwin-16
 * x86_64-darwin-15

--- a/lib/libv8/version.rb
+++ b/lib/libv8/version.rb
@@ -1,3 +1,3 @@
 module Libv8
-  VERSION = "7.3.492.27.3beta1"
+  VERSION = "7.3.495.0"
 end

--- a/libv8.gemspec
+++ b/libv8.gemspec
@@ -7,12 +7,10 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Charles Lowell"]
   s.email       = ["cowboyd@thefrontside.net"]
-  s.homepage    = "http://github.com/cowboyd/libv8"
+  s.homepage    = "http://github.com/rubyjs/libv8"
   s.summary     = %q{Distribution of the V8 JavaScript engine}
   s.description = %q{Distributes the V8 JavaScript engine in binary and source forms in order to support fast builds of The Ruby Racer}
   s.license     = "MIT"
-
-  s.rubyforge_project = "libv8"
 
   s.files  = `git ls-files`.split("\n").reject {|f| f =~ /^release\//}
 


### PR DESCRIPTION
## Changes

* I have requested TravisCI to extend timeout from 50m to 120m
* Bump to 7.3.495.0
* Drop testing against Ruby 2.4 (EOL) and rbx (precompiled version is old)
* Test against Ruby 2.6 and 2.7
* Drop testing with XCode 9.2 (the upstream tooling yield dylib error) - the objective now is to get a green build to unblock development - we could revisit this in a separate PR
