### PR TITLE
Update to 8.4.371.19

### DIFF
--- a/ext/libv8/builder.rb
+++ b/ext/libv8/builder.rb
@@ -65,7 +65,7 @@ module Libv8
     # then this will be 4.5.95
     #
     def source_version
-      Libv8::VERSION.gsub(/\.[^.]+$/, '')
+      Libv8::V8_MINOR_VERSION
     end
 
     ##
@@ -84,7 +84,7 @@ module Libv8
 
         Dir.chdir('v8') do
           system 'git fetch origin'
-          unless system "git checkout #{source_version}"
+          unless system "git checkout branch-heads/#{source_version}"
             fail "unable to checkout source for v8 #{source_version}"
           end
           system "gclient sync" or fail "could not sync v8 build dependencies"

--- a/ext/libv8/builder.rb
+++ b/ext/libv8/builder.rb
@@ -65,7 +65,7 @@ module Libv8
     # then this will be 4.5.95
     #
     def source_version
-      Libv8::V8_MINOR_VERSION
+      Libv8::VERSION.gsub(/\.[^.]+$/, '')
     end
 
     ##
@@ -84,7 +84,7 @@ module Libv8
 
         Dir.chdir('v8') do
           system 'git fetch origin'
-          unless system "git checkout branch-heads/#{source_version}"
+          unless system "git checkout #{source_version}"
             fail "unable to checkout source for v8 #{source_version}"
           end
           system "gclient sync" or fail "could not sync v8 build dependencies"

--- a/lib/libv8/version.rb
+++ b/lib/libv8/version.rb
@@ -1,3 +1,4 @@
 module Libv8
-  VERSION = "7.3.495.0"
+  V8_MINOR_VERSION = "8.4"
+  VERSION = "8.4.371.0"
 end

--- a/lib/libv8/version.rb
+++ b/lib/libv8/version.rb
@@ -1,4 +1,3 @@
 module Libv8
-  V8_MINOR_VERSION = "8.4"
-  VERSION = "8.4.371.0"
+  VERSION = "8.4.255.0"
 end


### PR DESCRIPTION

This is the version currently used by Chrome stable. 8.5 is in beta. see https://omahaproxy.appspot.com/ for more version information

Using .19﻿requires changing our checkout strategy to check out the branch-heads branch (as documented at https://v8.dev/docs/version-numbers) instead of using the 8.4.371 branch, which never gets patches (it's always locked to 8.4.371.0).

We could also specify the v8 patch version manually, and i'm open to doing that, just wanted to do this to get it working.
