### PR TITLE
Update to 8.4.255

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ lib/libv8/VERSION
 /release/**/.scaleway
 /vendor/.gclient
 /vendor/.gclient_entries
+/vendor/.cipd
 /vendor/v8/

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" -a "$TRAVIS_RUBY_VERSION" != "system" ]; then gem update bundler; fi
 script:
   - git submodule update --init
-  - bundle exec rake spec binary osx_varients --trace
+  - bundle exec rake spec binary --trace
+before_deploy:
+  - bundle exec rake osx_varients --trace
 deploy:
   provider: releases
   file_glob: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ rvm:
   - 2.5
 matrix:
   include:
-    - rvm: 2.6
-      os: osx
-      osx_image: xcode9.4.1
-  fast_finish: true
+    - os: osx
+      osx_image: xcode12
+    - os: osx
+      osx_image: xcode11.3
+    - os: osx
+      osx_image: xcode10.1
 addons:
   apt:
     packages:
@@ -25,19 +27,21 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" -a "$TRAVIS_RUBY_VERSION" != "system" ]; then gem update bundler; fi
 script:
   - git submodule update --init
-  - bundle exec rake spec binary --trace
+  - bundle exec rake spec binary osx_varients --trace
 deploy:
   provider: releases
-  file: $(git ls-files -o pkg | head -1)
+  file_glob: true
+  file: pkg/*.gem
   api_key:
     secure: OMCBceg89uRnU+FIPAPbeOK2pISvV4Cz62r9iTRIGXQCOOXX8M40i77/3DmtkMtc9FEuNyAu1+CH886PL2WtZZPK4CmEU3HuqXz1a5VsCI+zcAZL1tevKvblXOVQ3MG+B/SZRC3rEzGwjk4027WtzCCGoGCLUu4TFJP05+/8XN4=
   skip_cleanup: true
   on:
     tags: true
-    # condition: $TRAVIS_OS_NAME = osx
+    rvm: '2.7' # Only deploy 1 of each platform
 cache:
   bundler: true
 notifications:
   recipients:
     - cowboyd@thefrontside.net
     - bordjukov@gmail.com
+    - nightpool@cybre.space

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v8.4.255.0 - 2020-07-15
+
+* Update upstream v8 version to 8.4.255.0
+
 ### v7.3.495.0 - 2020-04-14
 
 * Update upstream v8 version to 7.3.495.0

--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ platforms.
 * x86_64-darwin-19
 * x86_64-darwin-18
 * x86_64-darwin-17
-* x86_64-darwin-16
-* x86_64-darwin-15
-* x86_64-darwin-14
 * x86_64-linux
 * x86-linux
 

--- a/ext/libv8/builder.rb
+++ b/ext/libv8/builder.rb
@@ -65,7 +65,7 @@ module Libv8
     # then this will be 4.5.95
     #
     def source_version
-      Libv8::VERSION.gsub(/\.[^.]+$/, '')
+      Libv8::V8_MINOR_VERSION
     end
 
     ##
@@ -84,7 +84,7 @@ module Libv8
 
         Dir.chdir('v8') do
           system 'git fetch origin'
-          unless system "git checkout #{source_version}"
+          unless system "git checkout branch-heads/#{source_version}"
             fail "unable to checkout source for v8 #{source_version}"
           end
           system "gclient sync" or fail "could not sync v8 build dependencies"

--- a/ext/libv8/builder.rb
+++ b/ext/libv8/builder.rb
@@ -23,7 +23,8 @@ module Libv8
          v8_use_external_startup_data=false
          target_cpu="#{libv8_arch}"
          v8_target_cpu="#{libv8_arch}"
-         treat_warnings_as_errors=false).join(' ')
+         treat_warnings_as_errors=false
+         icu_use_data_file=false).join(' ')
     end
 
     def generate_gn_args

--- a/ext/libv8/builder.rb
+++ b/ext/libv8/builder.rb
@@ -65,7 +65,7 @@ module Libv8
     # then this will be 4.5.95
     #
     def source_version
-      Libv8::V8_MINOR_VERSION
+      Libv8::VERSION.gsub(/\.[^.]+$/, '')
     end
 
     ##
@@ -84,7 +84,7 @@ module Libv8
 
         Dir.chdir('v8') do
           system 'git fetch origin'
-          unless system "git checkout branch-heads/#{source_version}"
+          unless system "git checkout #{source_version}"
             fail "unable to checkout source for v8 #{source_version}"
           end
           system "gclient sync" or fail "could not sync v8 build dependencies"

--- a/lib/libv8/version.rb
+++ b/lib/libv8/version.rb
@@ -1,3 +1,4 @@
 module Libv8
-  VERSION = "7.3.495.0"
+  V8_MINOR_VERSION = "8.4"
+  VERSION = "8.4.371.0"
 end

--- a/lib/libv8/version.rb
+++ b/lib/libv8/version.rb
@@ -1,4 +1,3 @@
 module Libv8
-  V8_MINOR_VERSION = "8.4"
-  VERSION = "8.4.371.0"
+  VERSION = "8.4.255.0"
 end


### PR DESCRIPTION
i.e. Use last good version before build error
    
Using bisect, I was able to find that the build error we saw in #300 and #299 was introduced in https://github.com/v8/v8/commit/5bbca548e9841d25645e0ed077638b1d96bd1f07, so let's use the version before that one while we wait for upstream to merge the fix I submitted (https://bugs.chromium.org/p/v8/issues/detail?id=10708)

closes #298, #299 and #281
