### PR TITLE
Update mac OS build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
       osx_image: xcode12
     - os: osx
       osx_image: xcode11.3
-    - os: osx
-      osx_image: xcode10.1
 addons:
   apt:
     packages:
@@ -39,7 +37,8 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    rvm: '2.7' # Only deploy 1 of each platform
+    rvm: '2.7'
+    osx_image: xcode12
 cache:
   bundler: true
 notifications:

--- a/Rakefile
+++ b/Rakefile
@@ -105,19 +105,21 @@ end
 task :default => [:compile, :spec]
 task :build => [:clean]
 
-desc 'Generate OSX varient platform names. Requires `compile` to already have been run.'
+desc 'Generate OSX platform builds. Although any v8 OSX compile will run on any Mac OS version down to 10.10, RubyGems requires us to submit all of the different platforms seperately. Requires `compile` to already have been run, but is seperate for Travis reasons.'
 task :osx_varients do
   gemspec = Helpers.binary_gemspec
-  next unless gemspec.platform.os == 'osx'
+  next unless Gem::Platform.local.os == 'darwin'
 
-  %w(x86_64 universal).each do |cpu|
-    platform = gemspec.platform.dup
-    next unless platform.cpu != cpu
+  [15, 16, 17, 18, 19].each do |version|
+    %w(x86_64 universal).each do |cpu|
 
-    platform.cpu = cpu
-    gemspec.platform = platform
+      gemspec.platform = Gem::Platform.local.tap do |platform|
+        platform.cpu = cpu
+        platform.version = version
+      end
 
-    package = Gem::Package.build gemspec
-    FileUtils.mv package, 'pkg'
+      package = Gem::Package.build gemspec
+      FileUtils.mv package, 'pkg'
+    end
   end
 end


### PR DESCRIPTION
Although any v8 OSX compile will run on any Mac OS version down to 10.10, RubyGems requires us to submit all of the different platforms seperately. This means that instead of running CI platforms for every OSX version we support, we can instead just create the gem on 1 platform, and then repackage it for all of the other platforms.﻿This avoids having to do dirty magic like convincing v8 to build with an older macos API version, which we would need to do to get v8 to compile on a 10.13 buildbot
